### PR TITLE
Remove Caching From SDK Requests

### DIFF
--- a/src/Cache/CacheManager.php
+++ b/src/Cache/CacheManager.php
@@ -55,7 +55,7 @@ abstract class CacheManager
     {
         $url = "{$uri->getHost()}{$uri->getPath()}";
 
-        return str_replace(['/', '.', '-', '@', '+'],'_',$url);
+        return preg_replace('/[^a-zA-Z0-9_\.!]/', '_', $url);
     }
 
     /**

--- a/src/Cache/CacheManager.php
+++ b/src/Cache/CacheManager.php
@@ -55,7 +55,7 @@ abstract class CacheManager
     {
         $url = "{$uri->getHost()}{$uri->getPath()}";
 
-        return preg_replace('/[^a-zA-Z0-9_\.!]/', '_', $url);
+        return str_replace(['/', '.', '-', '@', '+'],'_',$url);
     }
 
     /**

--- a/src/DataStore/DefaultDataStore.php
+++ b/src/DataStore/DefaultDataStore.php
@@ -265,13 +265,6 @@ class DefaultDataStore
      */
     public function executeRequest($method, UriInterface $uri, $body = '', array $options = [])
     {
-        // $cacheManager = $cacheManager = Client::getInstance()->getCacheManager();
-        // $cacheKey = $cacheManager->createCacheKey($uri);
-
-        // if ('GET' == $method && $cacheManager->pool()->hasItem($cacheKey)) {
-        //     return $cacheManager->pool()->getItem($cacheKey)->get();
-        // }
-
         $headers = [];
         $headers['Accept'] = 'application/json';
 
@@ -307,26 +300,6 @@ class DefaultDataStore
             throw new ResourceException($error);
         }
 
-        // if (!is_array($result)) {
-        //     switch ($method) {
-        //         case 'GET':
-        //             if (null !== $result) {
-        //                 $cacheManager->save($uri, $result);
-        //             }
-        //             break;
-        //         case 'POST':
-        //             if (null !== $result) {
-        //                 $cacheManager->delete($uri, $result);
-        //                 $cacheManager->save($uri, $result);
-        //             }
-        //             break;
-        //         case 'DELETE':
-        //             if (null !== $this->resource) {
-        //                 $cacheManager->delete($uri, $this->toStdClass($this->resource));
-        //             }
-        //             break;
-        //     }
-        // }
         return $result;
     }
 

--- a/src/DataStore/DefaultDataStore.php
+++ b/src/DataStore/DefaultDataStore.php
@@ -265,12 +265,12 @@ class DefaultDataStore
      */
     public function executeRequest($method, UriInterface $uri, $body = '', array $options = [])
     {
-        $cacheManager = $cacheManager = Client::getInstance()->getCacheManager();
-        $cacheKey = $cacheManager->createCacheKey($uri);
+        // $cacheManager = $cacheManager = Client::getInstance()->getCacheManager();
+        // $cacheKey = $cacheManager->createCacheKey($uri);
 
-        if ('GET' == $method && $cacheManager->pool()->hasItem($cacheKey)) {
-            return $cacheManager->pool()->getItem($cacheKey)->get();
-        }
+        // if ('GET' == $method && $cacheManager->pool()->hasItem($cacheKey)) {
+        //     return $cacheManager->pool()->getItem($cacheKey)->get();
+        // }
 
         $headers = [];
         $headers['Accept'] = 'application/json';
@@ -307,26 +307,26 @@ class DefaultDataStore
             throw new ResourceException($error);
         }
 
-        if (!is_array($result)) {
-            switch ($method) {
-                case 'GET':
-                    if (null !== $result) {
-                        $cacheManager->save($uri, $result);
-                    }
-                    break;
-                case 'POST':
-                    if (null !== $result) {
-                        $cacheManager->delete($uri, $result);
-                        $cacheManager->save($uri, $result);
-                    }
-                    break;
-                case 'DELETE':
-                    if (null !== $this->resource) {
-                        $cacheManager->delete($uri, $this->toStdClass($this->resource));
-                    }
-                    break;
-            }
-        }
+        // if (!is_array($result)) {
+        //     switch ($method) {
+        //         case 'GET':
+        //             if (null !== $result) {
+        //                 $cacheManager->save($uri, $result);
+        //             }
+        //             break;
+        //         case 'POST':
+        //             if (null !== $result) {
+        //                 $cacheManager->delete($uri, $result);
+        //                 $cacheManager->save($uri, $result);
+        //             }
+        //             break;
+        //         case 'DELETE':
+        //             if (null !== $this->resource) {
+        //                 $cacheManager->delete($uri, $this->toStdClass($this->resource));
+        //             }
+        //             break;
+        //     }
+        // }
         return $result;
     }
 


### PR DESCRIPTION
This eliminates calls to the CacheManager and thus the Cache system when making Okta API calls. We don't need to cache responses for our use of the Okta API and other options left too much room for potential collisions so it's better to just disable the cache entirely.